### PR TITLE
fix: Warning when button icon is a div instead of svg

### DIFF
--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -51,9 +51,7 @@ const Button: React.FC<ButtonProps> = ({
       disabled={disabled}
     >
       {icon && (iconPosition === "top" || iconPosition === "left") && (
-        <Typography className={`icon-${iconPosition} ${typographyClass}`}>
-          {icon}
-        </Typography>
+        <div className={`icon-${iconPosition} ${typographyClass}`}>{icon}</div>
       )}
 
       <Typography variant={typographyVariant} className={`${typographyClass}`}>
@@ -61,9 +59,7 @@ const Button: React.FC<ButtonProps> = ({
       </Typography>
 
       {icon && (iconPosition === "right" || iconPosition === "bottom") && (
-        <Typography className={`icon-${iconPosition} ${typographyClass}`}>
-          {icon}
-        </Typography>
+        <div className={`icon-${iconPosition} ${typographyClass}`}>{icon}</div>
       )}
     </button>
   );

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -35,12 +35,12 @@ const Header = React.memo(({ breadcrumbs, user }: HeaderProps) => {
           </Typography>
           <div className="flex cursor-pointer items-center antialiased transition-colors duration-100 bg-mono/basic-14 rounded-full h-fit">
             <div className="flex items-center py-2.25 pl-4 pr-5">
-              {breadcrumbs.map((breadcrumb) => (
+              {breadcrumbs.map((breadcrumb, index) => (
                 <Breadcrumb
+                  key={index}
                   text={breadcrumb.text}
                   isDropdown={breadcrumb.isDropdown}
                   shouldAddDivider={breadcrumb.shouldAddDivider}
-                  key={breadcrumb.text}
                 />
               ))}
             </div>

--- a/src/components/header/breadcrumb/generateBreadcrumbs.ts
+++ b/src/components/header/breadcrumb/generateBreadcrumbs.ts
@@ -19,7 +19,6 @@ export const generateBreadcrumbs = (pathname: string): BreadcrumbItem[] => {
       return null;
     }
   );
-
   return breadcrumbs.filter(
     (breadcrumb): breadcrumb is BreadcrumbItem => breadcrumb !== null
   );


### PR DESCRIPTION
# Description

Fixed an error that occurs when a button icon is placed inside of a div.

## Checklist before requesting a review

I have:

- [x] Performed a self-review of my code.
- [x] Commented hard-to-understand areas.
- [x] Ideally added tests that prove my fix is effective or that my feature works.
- [x] Ran `npm run reviewable` to ensure this PR is ready for review.
- [x] Made sure any dependent changes have been merged.
